### PR TITLE
Compatibility with Python 3 and scipy deprecations

### DIFF
--- a/EFIT2D.py
+++ b/EFIT2D.py
@@ -131,11 +131,11 @@ class EFIT2D:
 				for device in platform.get_devices():
 					if cl.device_type.to_string(device.type)== DEVICE:
 						my_device =				 device
-						print my_device.name, "	 ", cl.device_type.to_string(my_device.type)
+						print(my_device.name, "	 ", cl.device_type.to_string(my_device.type))
 
 		except:
 			my_device = cl.get_platforms()[0].get_devices()
-			print my_device.name, "	 ", cl.device_type.to_string(my_device.type)
+			print(my_device.name, "	 ", cl.device_type.to_string(my_device.type))
 
 		self.ctx    = cl.Context([my_device])
 		self.queue  = cl.CommandQueue(self.ctx)

--- a/EFIT2D_Classes.py
+++ b/EFIT2D_Classes.py
@@ -34,11 +34,9 @@ import		  numpy				  as      np
 from		  math				  import  sin, cos, sqrt, pi, exp
 import		  random
 import		  time
-from		  scipy.misc		  import  imresize
-from		  scipy.misc.pilutil  import  imrotate
-from		  scipy.weave		  import  inline
 from		  scipy				  import  signal
 from		  scipy.fftpack		  import  fftshift
+from skimage.transform import rotate
 
 try:
 	from	Image import		Image  
@@ -48,6 +46,15 @@ except:
 from		  matplotlib		  import  cm
 import		  matplotlib.pyplot	  as      plt
 
+
+def imresize(arr, size, **kwargs):
+    from PIL import Image
+    size_list = [int(arr.shape[0] * size), int(arr.shape[1] * size)]
+    return np.array(Image.fromarray(arr).resize(size_list))
+
+
+def imrotate(arr, angle, **kwargs):
+    return rotate(arr, angle=angle)
 
 
 def RaisedCosinePulse(t, Freq, Amplitude):
@@ -501,7 +508,7 @@ class Inspection:
 		self.YL +=	 (np.around(transducer.Offset * image.Pixel_mm * NRI / float(N_pml)))
 
 		self.IR		 = np.zeros((Ntheta,Ntheta),dtype=np.float32)
-		B			 = range(0,Ntheta)
+		B			 = list(range(0,Ntheta))
 		self.IR[:,0] = np.int32(B[:])
 
 		for i in range(1,Ntheta):
@@ -546,7 +553,7 @@ class Inspection:
 		M		  = np.size(x)
 		temp      = np.zeros((M,),dtype=np.float32)
 		for	 mm	in range(0,M):
-			temp[mm] = T[(x[mm]),(y[mm])]
+			temp[mm] = T[(int(x[mm])),(int(y[mm]))]
 		
 		return temp	
 		
@@ -638,7 +645,7 @@ class SimulationModel:
 		self.dt = self.TimeScale * np.float32( 0.7071 * self.dx / (	 np.max([V]) ) )
 
 			
-		self.Ntiempo = round(self.SimTime/self.dt)
+		self.Ntiempo = int(round(self.SimTime/self.dt))
 		self.t	= self.dt*np.arange(0,self.Ntiempo)
 	
 	
@@ -657,7 +664,7 @@ class SimulationModel:
 		self.Im		      =	 imresize(image.Itemp, self.Rgrid, interp='nearest')
 		self.MRI,self.NRI =	 np.shape(self.Im)
 	
-		print "dt: " + str(self.dt) + " dx: "  + str(self.dx) + " Grid: " +  str(self.MRI) + " x " + str(self.NRI)
+		print("dt: " + str(self.dt) + " dx: "  + str(self.dx) + " Grid: " +  str(self.MRI) + " x " + str(self.NRI))
 	
 		
 	def initReceivers(self):

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###efit2d-pyopencl
+### efit2d-pyopencl
 
 **Optimized OpenCL implementation of the Elastodynamic Finite Integration Technique for viscoelastic media**
 M. Molero-Armenta, Ursula Iturraran-Viveros, S. Aparicio, M.G. Hernández

--- a/main.py
+++ b/main.py
@@ -173,10 +173,10 @@ if __name__ == '__main__':
 	#Define Main EFIT2D Object
 	if VISCO:
 		FD = EFIT2D(image, materials, source, transducer, signal, simModel,"VISCOELASTIC", Local_Size)
-		print "Visco-EFIT2D"
+		print("Visco-EFIT2D")
 	else:
 		FD = EFIT2D(image, materials, source, transducer, signal, simModel,"ELASTIC", Local_Size)
-		print "Elastic-EFIT2D"
+		print("Elastic-EFIT2D")
 	
 	#setup receiver line (100 receivers)
 	y = np.linspace(1,100,100)
@@ -214,7 +214,7 @@ if __name__ == '__main__':
 				FD.n+=1
 
 				if FD.n % 500==0:
-					print str(FD.n)	 + " Total " + str(TimeIter)
+					print(str(FD.n)	 + " Total " + str(TimeIter))
 
 				if (FD.n % 500==0):
 				
@@ -231,7 +231,7 @@ if __name__ == '__main__':
 			else:
 				global start
 				stopT = time.time()-start
-				print "Total Computation Time: ", stopT
+				print("Total Computation Time: ", stopT)
 				
 				start = time.time()
 				#Retrieve the receiver signals from the computing device to the host
@@ -260,16 +260,16 @@ if __name__ == '__main__':
 			FD.Run()
 			FD.n+=1
 			if FD.n % 500 == 0:
-				print FD.n, " of total iterations: ", TimeIter
+				print(FD.n, " of total iterations: ", TimeIter)
 		
 
 		stopT = time.time()-start
-		print "Total Computation Time: ", stopT
+		print("Total Computation Time: ", stopT)
 
 		start = time.time()
 
 		#Retrieve the receiver signals from the computing device to the host
-		print "recovery"
+		print("recovery")
 		FD.saveOutput() #FD.receivers_signals
 
 		# Save simulation data: receivers, dt, dr, dz


### PR DESCRIPTION
- `scipy.weave` has been deprecated and removed altogether and it is now advised to use Cython. The original code imports `weave` but does not seem to be calling it. I simply removed the import.
- In `scipy`, `imrotate`, `imresize`, etc have been deprecated and removed. I used the libraries suggested by the `scipy` documentation to replace these functions. This is a bit hacky as certain arguments are not respected _e.g._ `interp`.
- I modified `print` statements to be Python 3 compatible